### PR TITLE
Parse model metadata from GCode

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -31,6 +31,8 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
+#include "../../../src/libs/duration_t.h"
+
 #if ANY(HAS_HOTEND, HAS_HEATED_BED, HAS_FAN) && PREHEAT_COUNT
   #define HAS_PREHEAT 1
   #if PREHEAT_COUNT < 2
@@ -897,6 +899,7 @@ void Draw_Status_Area(bool with_update);
 void Draw_Mid_Status_Area(bool with_update);
 void update_variable();
 void update_middle_variable();
+duration_t estimate_remaining_time(const duration_t elapsed);
 void Draw_laguage_Cursor(uint8_t line);
 void In_out_feedtock(uint16_t _distance,uint16_t _feedRate,bool dir);
 void In_out_feedtock_level(uint16_t _distance,uint16_t _feedRate,bool dir);

--- a/Marlin/src/lcd/dwin/e3v2/lcd_rts.h
+++ b/Marlin/src/lcd/dwin/e3v2/lcd_rts.h
@@ -46,6 +46,13 @@ enum{
   PIC_RESOLITION_ERR,  // 图片分辨率错误
   PIC_MISS_ERR,        // gcode无图片
 };
+enum{
+  METADATA_PARSE_OK,
+  METADATA_PARSE_ERROR,
+};
+
+#define _GCODE_METADATA_STRING_LENGTH_MAX 80
+#define _MAX_LINES_TO_PARSE 50
 
 typedef struct _model_information_t
 {
@@ -95,6 +102,6 @@ extern model_information_t model_information;
 #define VP_OVERLAY_PIC_PTINT_DACAI        0xB001              /* 打印界面的预览图 -- 特殊处理大彩屏，预览图地址不能重复 */
 
 extern uint8_t gcodePicDataSendToDwin(char *, unsigned int , unsigned char , unsigned char );
-extern uint8_t read_gcode_model_information(void);
+extern uint8_t read_gcode_model_information(const char* fileName);
 extern char Parse_Only_Picture_Data(char* fileName,char * time, char * FilamentUsed, char * layerHeight);
 #endif


### PR DESCRIPTION
Currently firmware does not parse any metadata from the gcode file and uses crude approximation algorithm to show print time. Parsing basic model parameters not only allows showing them in file select menu, but also show proper print time estimation during the print

This should mostly fix the #35 as it now uses parsed metadata from gcode, generated by Cura/PrusaSlicer/CrealityPrint. It does not support metadata provided by OrcaSlicer, since it's given at the end of the file and is of completely different format.

![image](https://github.com/user-attachments/assets/364f50ee-57a5-4297-ad42-4e359c722feb)

![image](https://github.com/user-attachments/assets/7e200291-4f05-4e7c-8c5a-3c05c4e3911c)